### PR TITLE
update readme

### DIFF
--- a/examples-standalone/finance-portfolio/README.md
+++ b/examples-standalone/finance-portfolio/README.md
@@ -33,7 +33,7 @@ Note: This sample project is an Angular CLI project:
 
 ## Getting Started
 
-1. Clone the repository of the sample application locally by running `git clone https://github.com/telerik/kendo-angular/`.
+1. Clone the repository of the sample application locally by running `git clone https://github.com/telerik/kendo-angular.git`.
 1. Navigate to the project folder by running `cd examples-standalone/finance-portfolio`.
 1. Install dependencies with NPM by running `npm install`.
 

--- a/examples-standalone/finance-portfolio/README.md
+++ b/examples-standalone/finance-portfolio/README.md
@@ -33,8 +33,8 @@ Note: This sample project is an Angular CLI project:
 
 ## Getting Started
 
-1. Clone the repository of the sample application locally by running `git clone https://github.com/telerik/kendo-angular/.git`.
-1. Navigate to the project folder by running `cd examples-standalone/kendo-ng-finance-app`.
+1. Clone the repository of the sample application locally by running `git clone https://github.com/telerik/kendo-angular/`.
+1. Navigate to the project folder by running `cd examples-standalone/finance-portfolio`.
 1. Install dependencies with NPM by running `npm install`.
 
 


### PR DESCRIPTION
## Correcting the path to this project folder
The app is now under `examples-standalone/finance-portfolio`.

## Correcting the clone URL
If `.git` is on the end, you get an error when trying to clone:

![image](https://user-images.githubusercontent.com/1058831/80518345-f558a000-894b-11ea-85c3-2cb61b253c0c.png)
