### PR TITLE
chore: add @angular/animations to examples deps

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -76,6 +76,7 @@
     "@angular-eslint/template-parser": "13.2.1",
     "@angular/cli": "~13.3.7",
     "@angular/compiler-cli": "~13.3.10",
+    "@angular/animations": "~13.3.10",
     "@angular/language-service": "~13.3.10",
     "@progress/kendo-angular-messages": "^1.33.0",
     "@types/jasmine": "~4.0.3",


### PR DESCRIPTION
I believe that the master build is failing because the standalone apps use the node_modules installed from the `examples` package.json https://github.com/telerik/kendo-angular/blob/master/examples/package.json and @angular/animations is missing there (corresponds to the error we are getting).

The error is thrown while executing the `build-gh-pages` [script](https://github.com/telerik/kendo-angular/blob/master/examples/bin/build-gh-pages) which is inside the `examples` directory