### PR TITLE
chore: update angular.json builder

### DIFF
--- a/examples-standalone/coffee-warehouse/angular.json
+++ b/examples-standalone/coffee-warehouse/angular.json
@@ -19,7 +19,7 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:application",
           "options": {
             "allowedCommonJsDependencies": [
               "hammerjs",
@@ -29,7 +29,7 @@
             ],
             "outputPath": "dist/coffee-warehouse",
             "index": "src/index.html",
-            "main": "src/main.ts",
+            "browser": "src/main.ts",
             "polyfills": [
                 "zone.js"
               ],
@@ -57,9 +57,7 @@
               "src/styles/main.scss"
             ],
             "scripts": [],
-            "vendorChunk": true,
             "extractLicenses": false,
-            "buildOptimizer": false,
             "sourceMap": true,
             "optimization": false,
             "namedChunks": true
@@ -77,8 +75,6 @@
               "sourceMap": false,
               "namedChunks": false,
               "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true,
               "budgets": [
                 {
                   "type": "initial",
@@ -92,7 +88,7 @@
               ]
             }
           },
-          "defaultConfiguration": ""
+          "defaultConfiguration": "production"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",

--- a/examples-standalone/coffee-warehouse/package-lock.json
+++ b/examples-standalone/coffee-warehouse/package-lock.json
@@ -46,7 +46,9 @@
         "@progress/kendo-drawing": "^1.19.0",
         "@progress/kendo-licensing": "^1.0.2",
         "@progress/kendo-svg-icons": "^2.0.0",
+        "@progress/kendo-theme-bootstrap": "^7.2.0",
         "@progress/kendo-theme-default": "^7.2.0",
+        "@progress/kendo-theme-material": "^7.2.0",
         "hammerjs": "^2.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -3218,6 +3220,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@progress/jszip-esm": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@progress/jszip-esm/-/jszip-esm-1.0.3.tgz",
@@ -4019,27 +4031,50 @@
       "resolved": "https://registry.npmjs.org/@progress/kendo-svg-icons/-/kendo-svg-icons-2.1.0.tgz",
       "integrity": "sha512-zAwxw8lt5xlIBMoE3uwUX2Z2RI5njWViYxdFoinvr5d8WJ6kU3sghNONsRelM9GiDd2vbSg0IkEN8dOrBvFjPg=="
     },
-    "node_modules/@progress/kendo-theme-core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-core/-/kendo-theme-core-7.2.0.tgz",
-      "integrity": "sha512-jzXzL0TY+6GpqVtQF9EIdy5EW81S9EEFAFEd2B7Zi1eN9WjGn7agDaAi6+hKNsCMBIv81Vmxahvs6C16ccU3UA=="
-    },
-    "node_modules/@progress/kendo-theme-default": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-default/-/kendo-theme-default-7.2.0.tgz",
-      "integrity": "sha512-57cf6Cwl94S87dNhOQwajEbAaPcLnq0jL9jxxMEG/cY18y3ErGrTy1jaUvsSfIHEEMgKVUqkTdb4+Od6dKrSaA==",
+    "node_modules/@progress/kendo-theme-bootstrap": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-bootstrap/-/kendo-theme-bootstrap-7.2.1.tgz",
+      "integrity": "sha512-lQcx6z9zKxtXwR5BtvSe4ZPs/TWxWzNNzvyh7ke5EekanWU8q1AY+7wntM6q6D7haWBdbAtqe0odmUiSaG2C8w==",
       "dependencies": {
         "@progress/kendo-svg-icons": "2.1.0",
-        "@progress/kendo-theme-core": "7.2.0",
-        "@progress/kendo-theme-utils": "7.2.0"
+        "@progress/kendo-theme-core": "7.2.1",
+        "@progress/kendo-theme-default": "7.2.1",
+        "@progress/kendo-theme-utils": "7.2.1",
+        "bootstrap": "5.2.1"
+      }
+    },
+    "node_modules/@progress/kendo-theme-core": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-core/-/kendo-theme-core-7.2.1.tgz",
+      "integrity": "sha512-fv6ELPjmQWw5p7ksv96RIiSWMQKenXdkK6b96vSakoQcexR/4oKDgbEXnApxeLgTUimh8Hp8M+6JIoZm+EQhyA=="
+    },
+    "node_modules/@progress/kendo-theme-default": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-default/-/kendo-theme-default-7.2.1.tgz",
+      "integrity": "sha512-WUMg+GZKpP37WL0aeGRi3i8vNmfEJdb5nHVBWAZeuEi/AS8cycVOCwcdDK4NywK9bUI/I0eUvLToxydLOHv6Pg==",
+      "dependencies": {
+        "@progress/kendo-svg-icons": "2.1.0",
+        "@progress/kendo-theme-core": "7.2.1",
+        "@progress/kendo-theme-utils": "7.2.1"
+      }
+    },
+    "node_modules/@progress/kendo-theme-material": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-material/-/kendo-theme-material-7.2.1.tgz",
+      "integrity": "sha512-mXKHb2qkzBjk0UyYKSZYYz5HVCh6Yd0o9z1eE7YzmZPCdDwbb+5wosFMpAgn2agNQh8uI5YlKV48yaoyWkCy5w==",
+      "dependencies": {
+        "@progress/kendo-svg-icons": "2.1.0",
+        "@progress/kendo-theme-core": "7.2.1",
+        "@progress/kendo-theme-default": "7.2.1",
+        "@progress/kendo-theme-utils": "7.2.1"
       }
     },
     "node_modules/@progress/kendo-theme-utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-utils/-/kendo-theme-utils-7.2.0.tgz",
-      "integrity": "sha512-13iVDNFr8JBI92PGaKG4KuCi5fgD6q+mrFztLLJ9CNhlHzSiPSXESMn3o2YkMYzKJbYObYNn9FubWqcS9Uzp6w==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@progress/kendo-theme-utils/-/kendo-theme-utils-7.2.1.tgz",
+      "integrity": "sha512-2IzRoBkjb2yolzJoQBZcsccmHT5a6GDw52O/PBXZHsxc5Cir7ej9CjP3tO2O4rWRg+8GfNEzB5XpwUb54lLF0Q==",
       "dependencies": {
-        "@progress/kendo-theme-core": "7.2.0"
+        "@progress/kendo-theme-core": "7.2.1"
       }
     },
     "node_modules/@progress/pako-esm": {
@@ -5284,6 +5319,24 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
+    },
+    "node_modules/bootstrap": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.1.tgz",
+      "integrity": "sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.6"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/examples-standalone/coffee-warehouse/package.json
+++ b/examples-standalone/coffee-warehouse/package.json
@@ -49,6 +49,8 @@
     "@progress/kendo-licensing": "^1.0.2",
     "@progress/kendo-svg-icons": "^2.0.0",
     "@progress/kendo-theme-default": "^7.2.0",
+    "@progress/kendo-theme-material": "^7.2.0",
+    "@progress/kendo-theme-bootstrap": "^7.2.0",
     "hammerjs": "^2.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
Updates the angular.json builder so that the output `dist` folder follows the same folder structure inside as the rest of the updated standalone apps. More specifically, the gh_pages publish script relies on that structure to properly gather the needed files and publish the apps.

The folder that it looks for is `dist/coffee-warehouse/browser` and the `browser` part is missing with the current setup.