### PR TITLE
chore: updated macos action image version due to deprecation

### DIFF
--- a/examples-standalone/electron-dashboard/.github/workflows/macos.yml
+++ b/examples-standalone/electron-dashboard/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: [20]
 
     # The type of runner that the job will run on
-    runs-on: macos-12
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Ref.: https://github.com/actions/runner-images/issues/10721