### PR TITLE
chore(cd): add environment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    environment: github-pages
 
     permissions:
       pages: write


### PR DESCRIPTION
Deployment to GH pages requires an environment.